### PR TITLE
(actions) generate new cache each day

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
       - name: Cache ccache
         uses: actions/cache@v3
         with:
           path: |
             ~/.ccache
-          key: ${{ runner.os }}-ccache-${{ github.event.repository.name }}-${{ github.sha }}
+          key: ${{ runner.os }}-ccache-${{ steps.get-date.outputs.date }}
           restore-keys: |
-            ${{ runner.os }}-ccache-${{ github.event.repository.name }}-
             ${{ runner.os }}-ccache-
       - name: Install
         run: |


### PR DESCRIPTION
This repo is not updated regularly. Therefore the latest commit is often te same. The commit SHA was used to label the cache. When cache exists with the same label, it isn't overwritten. Old cache is dropped when it has not been accessed in the last week. But the actions runs daily. So when the HEAD commit doesn't change, the same cache will be used. Which can become very old over time.

While the cache stays old. The packages that generate the cache can be updated in the meantime. So the cache should be updated along. By storing the cache by date. It will use the cache of yesterday, but it will generate a new cache. Which will be used the next day. GH actions will clean up the old caches.