### PR TITLE
(actions) use GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=:$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Cache ccache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "date=:$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Cache ccache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
set-output is deprecated, see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/